### PR TITLE
Add check to ensure only info of unique users are saved

### DIFF
--- a/src/file_auto_expiry/utils/interface.py
+++ b/src/file_auto_expiry/utils/interface.py
@@ -140,7 +140,8 @@ def collect_creator_information(path_info_file, save_file, scrape_time):
                         creator_info[user[1]]["paths"][path_data["path"]] = time_vars
                         
                     else:
-                        creator_info[user[1]] = {
+                        if isinstance(user[1], int):
+                            creator_info[user[1]] = {
                             "paths": {path_data["path"]: time_vars}, 
                             "name": user[0],
                             "uid": user[1],


### PR DESCRIPTION
There is a small issue where a global user (userid: s) is being saved as a contributor to seemingly every directory. As such, this patch adds a small check to ensure that the uid follows the watcloud system of int uids for unique users. 