### PR TITLE
Revert disabling atime for folders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "file_auto_expiry"
-version = "0.0.7"
+version = "0.0.8"
 description = "WATCloud project containing scripts to check if directories / files are expired"
 readme = "README.md"
 requires-python = ">=3.7, <4"

--- a/src/file_auto_expiry/utils/expiry_checks.py
+++ b/src/file_auto_expiry/utils/expiry_checks.py
@@ -92,7 +92,7 @@ def is_expired_folder(folder_path, folder_stat, expiry_threshold):
     """
     file_creators = set()
     # timestamps for the folder itself 
-    recent_atime = 0
+    recent_atime = folder_stat.st_atime
     recent_ctime = folder_stat.st_ctime
     recent_mtime = folder_stat.st_mtime
     folder_creator = get_file_creator(folder_path)


### PR DESCRIPTION
We disabled tracking the atime of folders for testing the functionality of the file expiry emails. This was because previous versions of this library had been updating the atime of folders while collecting data and so the atime info is not useful to us right now. 

We should change to using this version of the library after another month and a half have passed at least. 