### PR TITLE
Added option to use or disuse atime for directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "file_auto_expiry"
-version = "0.0.8"
+version = "0.0.9"
 description = "WATCloud project containing scripts to check if directories / files are expired"
 readme = "README.md"
 requires-python = ">=3.7, <4"

--- a/src/file_auto_expiry/main.py
+++ b/src/file_auto_expiry/main.py
@@ -5,7 +5,7 @@ import typer
 app = typer.Typer()
 
 @app.command()
-def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10):
+def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10, check_folder_atime: bool = False):
     """
     Collects information about the top level paths within a given folder path
     And dumps it into a json file, specified by the save_file flag
@@ -16,7 +16,8 @@ def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10)
     collect_expired_file_information(folder_path=path, 
                                      save_file=save_file, 
                                      scrape_time=scrape_time, 
-                                     expiry_threshold=expiry_threshold)
+                                     expiry_threshold=expiry_threshold,
+                                     check_folder_atime=check_folder_atime)
 
 @app.command()
 def collect_creator_info(file_info: str, save_file: str = ""):


### PR DESCRIPTION
Added optional flag to use or disuse the atime for folders when checking expiry

We are temporarily disabling the use of atime for folders. This is because previous testing in this project updated the atime of all folders in the /var/lib/clusters/users directory, and so it is not valuable to check the atime or those folders anymore. 