### PR TITLE
Add flag to overwrite or append new info to an existing file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "file_auto_expiry"
-version = "0.0.9"
+version = "0.0.10"
 description = "WATCloud project containing scripts to check if directories / files are expired"
 readme = "README.md"
 requires-python = ">=3.7, <4"

--- a/src/file_auto_expiry/main.py
+++ b/src/file_auto_expiry/main.py
@@ -5,7 +5,7 @@ import typer
 app = typer.Typer()
 
 @app.command()
-def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10, check_folder_atime: bool = False):
+def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10, check_folder_atime: bool = False, overwrite_file: bool = True):
     """
     Collects information about the top level paths within a given folder path
     And dumps it into a json file, specified by the save_file flag
@@ -17,10 +17,11 @@ def collect_file_info(path: str, save_file: str = "", days_for_expiry: int = 10,
                                      save_file=save_file, 
                                      scrape_time=scrape_time, 
                                      expiry_threshold=expiry_threshold,
-                                     check_folder_atime=check_folder_atime)
+                                     check_folder_atime=check_folder_atime,
+                                     overwrite_file=overwrite_file)
 
 @app.command()
-def collect_creator_info(file_info: str, save_file: str = ""):
+def collect_creator_info(file_info: str, save_file: str = "", overwrite_file: bool = True):
     """
     Tabulates the paths that relate to specific users, based on a given jsonl path
     That jsonl path should be the result of calling the collect_file_info function
@@ -29,7 +30,8 @@ def collect_creator_info(file_info: str, save_file: str = ""):
     scrape_time = time.time()
     collect_creator_information(path_info_file=file_info, 
                                 save_file=save_file, 
-                                scrape_time=scrape_time)
+                                scrape_time=scrape_time,
+                                overwrite_file=overwrite_file)
 
 if __name__ == "__main__":
     app()

--- a/src/file_auto_expiry/utils/interface.py
+++ b/src/file_auto_expiry/utils/interface.py
@@ -50,7 +50,7 @@ def scan_folder_for_expired(folder_path, expiry_threshold, check_folder_atime):
                 expiry_result.atime, expiry_result.ctime, expiry_result.mtime
     os.close(dirfd)
 
-def collect_expired_file_information(folder_path, save_file, scrape_time, expiry_threshold, check_folder_atime):
+def collect_expired_file_information(folder_path, save_file, scrape_time, expiry_threshold, check_folder_atime, overwrite_file=True):
     """
     Interface function which collects which directories are 'expired'
 
@@ -83,26 +83,27 @@ def collect_expired_file_information(folder_path, save_file, scrape_time, expiry
                 "mtime_datetime": str(datetime.datetime.fromtimestamp(mtime)),
             }}        
     
-    write_jsonl_information(path_info, save_file, scrape_time, expiry_threshold)
+    write_jsonl_information(path_info, save_file, scrape_time, expiry_threshold, overwrite_file=overwrite_file)
 
-def write_jsonl_information(dict_info, file_path, scrape_time, expiry_threshold=""):
+def write_jsonl_information(dict_info, file_path, scrape_time, expiry_threshold="", overwrite_file=True):
     current_time = time.time()
-
-    with open(file_path, "w") as file:
-        if expiry_threshold=="":
-            file.write(json.dumps({"scrape_time:": scrape_time,
-                               "scrape_time_datetime": str(datetime.datetime.fromtimestamp(scrape_time))}) + "\n")
-        else:
-            file.write(json.dumps({"scrape_time:": scrape_time,
-                               "scrape_time_datetime": str(datetime.datetime.fromtimestamp(scrape_time)),
-                               "expiry_threshold": str(datetime.datetime.fromtimestamp(expiry_threshold))}) + "\n")
-        file.write(json.dumps({"time_for_scrape_sec": current_time - scrape_time,
-                               "time_for_scrape_min": (current_time - scrape_time) / 60}) + "\n")
-        
+    mode = "w" if overwrite_file else "a+"
+    with open(file_path, mode) as file:
+        if (overwrite_file):
+            if expiry_threshold=="":
+                file.write(json.dumps({"scrape_time:": scrape_time,
+                                "scrape_time_datetime": str(datetime.datetime.fromtimestamp(scrape_time))}) + "\n")
+            else:
+                file.write(json.dumps({"scrape_time:": scrape_time,
+                                "scrape_time_datetime": str(datetime.datetime.fromtimestamp(scrape_time)),
+                                "expiry_threshold": str(datetime.datetime.fromtimestamp(expiry_threshold))}) + "\n")
+            file.write(json.dumps({"time_for_scrape_sec": current_time - scrape_time,
+                                "time_for_scrape_min": (current_time - scrape_time) / 60}) + "\n")
+            
         for key in dict_info:
             file.write(json.dumps(dict_info[key]) + "\n") 
 
-def collect_creator_information(path_info_file, save_file, scrape_time):
+def collect_creator_information(path_info_file, save_file, scrape_time, overwrite_file=True):
     """
     Returns a dictionary relating path information to each creator
     Must be given the return value of form similar to the output of 
@@ -146,5 +147,4 @@ def collect_creator_information(path_info_file, save_file, scrape_time):
                             "name": user[0],
                             "uid": user[1],
                             "gid": user[2]}
-        
-    write_jsonl_information(creator_info, save_file, scrape_time)
+    write_jsonl_information(creator_info, save_file, scrape_time, overwrite_file=overwrite_file)


### PR DESCRIPTION
Current implementation will just replace overwrite file contents on every call. This change adds an optional flag to append information onto an existing file. 

No changes required to current instances of use. 